### PR TITLE
Use absolute URL for MCP API requests

### DIFF
--- a/ui/src/components/McpClient.tsx
+++ b/ui/src/components/McpClient.tsx
@@ -7,6 +7,8 @@ import MenuItem from "@mui/material/MenuItem";
 import Typography from "@mui/material/Typography";
 import CircularProgress from "@mui/material/CircularProgress";
 
+const MCP_API_URL = "https://diabetes-675059836631.us-central1.run.app/mcp";
+
 // Parameter Types
 interface PatientData {
   PatientName: string;
@@ -149,7 +151,7 @@ export default function McpClient() {
         parameters: parsedParams
       });
 
-      const res = await axios.post("/mcp", { action, parameters: parsedParams });
+      const res = await axios.post(MCP_API_URL, { action, parameters: parsedParams });
       setResponse(JSON.stringify(res.data, null, 2));
     } catch (err) {
       if (axios.isAxiosError(err)) {


### PR DESCRIPTION
Updated McpClient.tsx to use the absolute URL (https://diabetes-675059836631.us-central1.run.app/mcp) for API requests to the /mcp endpoint.

This change directs requests to the specific backend service, which should help resolve potential 405 errors caused by requests previously being sent to a relative path on the frontend's domain.