### PR TITLE
Refactor async calls to fix asyncio.run error

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -556,7 +556,7 @@ async def get_expert_recommendations(patient_data, risk_result):
     return expert_recommendations    
               
 # Generate Final Consolidated Recommendation
-def get_final_recommendation(patient_data, expert_recommendations, risk_result):
+async def get_final_recommendation(patient_data, expert_recommendations, risk_result):
     meta_agent_prompt = PromptTemplate(
         input_variables=['endocrinologist', 'dietitian', 'fitness', 'patient', 'risk_result'],
         template=(
@@ -574,7 +574,7 @@ def get_final_recommendation(patient_data, expert_recommendations, risk_result):
 
     meta_agent_chain = LLMChain(llm=llm, prompt=meta_agent_prompt)
 
-    final_recommendation = meta_agent_chain.run(
+    final_recommendation = await meta_agent_chain.arun(
         endocrinologist=expert_recommendations["Endocrinologist"],
         dietitian=expert_recommendations["Dietitian"],
         fitness=expert_recommendations["Fitness Expert"],
@@ -613,7 +613,7 @@ async def get_recommendations(patient: PatientData):
                 "Fitness Expert": "No recommendations available."
             }
 
-        final_recommendation = get_final_recommendation(patient_data, expert_recommendations, risk_result)
+        final_recommendation = await get_final_recommendation(patient_data, expert_recommendations, risk_result)
 
         return {
             "endocrinologistRecommendation": expert_recommendations.get("Endocrinologist", "No data"),
@@ -630,7 +630,7 @@ async def get_recommendations(patient: PatientData):
 @app.post("/mcp", response_model=MCPResponse)
 async def mcp_endpoint(request: MCPRequest):
     try:
-        data = handle_mcp_action(request.action, request.parameters)
+        data = await handle_mcp_action(request.action, request.parameters)
         return MCPResponse(status="ok", data=data)
     except Exception as e:
         return MCPResponse(status="error", error=str(e))
@@ -686,7 +686,7 @@ async def chat(chat_request: ChatRequest):
         formatted_recommendations = "\n".join([f"- {key}: {value}" for key, value in cleaned_recommendations.items()])
 
         # Pass System Prompt as Context in LLM Response Generation
-        response = chat_chain.run(
+        response = await chat_chain.arun(
             history=f"{system_prompt}\n{formatted_history}",
             user_input=chat_request.user_input,
             patient_data=formatted_patient_data,

--- a/server/mcp.py
+++ b/server/mcp.py
@@ -68,7 +68,7 @@ def get_metadata() -> Dict[str, Optional[str]]:
 
 # --- Modified handle_mcp_action to return Pydantic data models directly ---
 # The return type hint is updated to reflect the Pydantic data models being returned.
-def handle_mcp_action(action: str, parameters: Optional[Dict[str, Any]] = None) -> Union[ModelListResponseData, CurrentModelResponseData, MetadataResponseData, Dict[str, Any]]:
+async def handle_mcp_action(action: str, parameters: Optional[Dict[str, Any]] = None) -> Union[ModelListResponseData, CurrentModelResponseData, MetadataResponseData, Dict[str, Any]]:
     """
     Handles different MCP actions and returns the appropriate data for the response.
     Returns Pydantic model instances for clarity and validation.
@@ -113,8 +113,8 @@ def handle_mcp_action(action: str, parameters: Optional[Dict[str, Any]] = None) 
         }
         risk_result = main.predict_diabetes_risk(patient_dict, compute_shap=False)
         cleaned_patient = main.convert_categorical_values(patient_dict.copy())
-        expert = asyncio.run(main.get_expert_recommendations(cleaned_patient, risk_result))
-        final_rec = main.get_final_recommendation(patient_dict, expert, risk_result)
+        expert = await main.get_expert_recommendations(cleaned_patient, risk_result)
+        final_rec = await main.get_final_recommendation(patient_dict, expert, risk_result)
         return {
             "endocrinologistRecommendation": expert.get("Endocrinologist", "No data"),
             "dietitianRecommendation": expert.get("Dietitian", "No data"),
@@ -126,7 +126,7 @@ def handle_mcp_action(action: str, parameters: Optional[Dict[str, Any]] = None) 
             raise ValueError("chat parameters required")
         import asyncio
         chat_request = main.ChatRequest(**parameters)
-        return asyncio.run(main.chat(chat_request))
+        return await main.chat(chat_request)
     raise ValueError("Unsupported MCP action")
 
 # --- Example of how this would be used in a web framework endpoint (e.g., FastAPI) ---


### PR DESCRIPTION
Resolved the 'asyncio.run() cannot be called from a running event loop' error by refactoring the handling of 'chat' and 'recommendations' actions in the MCP server.

Key changes:
- Made `mcp.handle_mcp_action` an `async def` function.
- Replaced `asyncio.run()` calls in `mcp.handle_mcp_action` with `await` for `main.chat` and `main.get_expert_recommendations`.
- Updated `main.mcp_endpoint` to `await` the call to `mcp.handle_mcp_action`.
- Changed synchronous LangChain calls (`.run()`) to their asynchronous counterparts (`await .arun()`) in `main.chat` and `main.get_final_recommendation`.
- Made `main.get_final_recommendation` an `async def` function and updated its callers to use `await`.

These changes ensure that asynchronous operations are correctly handled within the FastAPI event loop, preventing conflicts and improving async consistency.